### PR TITLE
On empty `path`, don't add a trailing slash.

### DIFF
--- a/src/Restful/Endpoint.elm
+++ b/src/Restful/Endpoint.elm
@@ -635,7 +635,11 @@ tokenUrlParam =
 (</>) left right =
     case ( String.endsWith "/" left, String.startsWith "/" right ) of
         ( False, False ) ->
-            left ++ "/" ++ right
+            if String.isEmpty right then
+                -- The `path` is empty, so don't add a trailing slash.
+                left
+            else
+                left ++ "/" ++ right
 
         ( True, True ) ->
             left ++ String.dropLeft 1 right

--- a/src/Restful/Endpoint.elm
+++ b/src/Restful/Endpoint.elm
@@ -630,22 +630,27 @@ tokenUrlParam =
 
     "http://www.apple.com/" </> "/path" --> "http://www.apple.com/path"
 
+    "" </> "path" --> "path"
+
+    "http://www.apple.com/path" </> "" --> "http://www.apple.com/path"
+
 -}
 (</>) : String -> String -> String
 (</>) left right =
-    case ( String.endsWith "/" left, String.startsWith "/" right ) of
-        ( False, False ) ->
-            if String.isEmpty right then
-                -- The `path` is empty, so don't add a trailing slash.
-                left
-            else
+    if String.isEmpty left then
+        right
+    else if String.isEmpty right then
+        left
+    else
+        case ( String.endsWith "/" left, String.startsWith "/" right ) of
+            ( False, False ) ->
                 left ++ "/" ++ right
 
-        ( True, True ) ->
-            left ++ String.dropLeft 1 right
+            ( True, True ) ->
+                left ++ String.dropLeft 1 right
 
-        _ ->
-            left ++ right
+            _ ->
+                left ++ right
 
 
 decodeItemList : EndPoint w e k v c p -> Decoder (List ( k, v ))


### PR DESCRIPTION
I have a backend where the backendUrl always changes (it's an AWS S3, where each URL has its own static json.

```elm
endpoint : ReadOnlyEndPoint Http.Error ItemUuid StaticItem ()
endpoint =
    -- The backend URL is always different -- it's the one in AWS S3, so we don't
    -- need to provide also the path. So, we just provide an empty string.
    Restful.Endpoint.endpoint "" decodeEntityUuid decodeStaticItem backend
```

If we have a trailing slash, we get a 404 from S3.