### PR TITLE
Don't hit user/logout on Drupal config

### DIFF
--- a/src/Restful/Login.elm
+++ b/src/Restful/Login.elm
@@ -945,7 +945,7 @@ restful implementation.
 drupalConfig : AppConfig anonymousData user authenticatedData msg -> Config anonymousData user authenticatedData msg
 drupalConfig appConfig =
     { loginPath = "api/login-token"
-    , logoutPath = Just "user/logout"
+    , logoutPath = Nothing
     , userPath = "api/me"
     , decodeAccessToken = field "access_token" JD.string
     , decodeUser = appConfig.decodeUser


### PR DESCRIPTION
As we have an access token, it is rare we'll need to hit that endpoint.